### PR TITLE
add chef mate

### DIFF
--- a/docs/blog/posts/2026-06-07-chef-mate.md
+++ b/docs/blog/posts/2026-06-07-chef-mate.md
@@ -12,4 +12,18 @@ Chef Mate is an open source Kotlin Multiplatform recipe keeper, meal planner, an
 
 <!-- more -->
 
+## The backstory
+
+I got laid off back in February after 3.5 years at Square. In my time there I learned how to construct an Android app that could scale across large teams with a very clean module structure for building out features. However, instead of just Android, I went with Kotlin Multiplatform (KMP) to target iOS and the JVM (Windows, Mac, and Linux) as well.
+
+The project originally started off without AI, where I established the architecture, but has since evolved with the use of AI — mainly Claude. It's been a journey learning a bunch of things along the way, but I've also taken the time to train Claude to work the way I would work, drawing on the last 8 years of how I build software.
+
+The code is open source and free right now. I wanted to share what is usually a fairly novel app — a grocery list — but expanded into something I'd consider an advanced KMP sample: a full recipe keeper, meal planner, and grocery list rolled into one.
+
+## Try it out
+
 Check it out live at [chefmate.plusmobileapps.com](https://chefmate.plusmobileapps.com/) or browse the source on [GitHub](https://github.com/Plus-Mobile-Apps/chef-mate).
+
+## Hire me
+
+I'm currently seeking employment. If you like the work you see and want me at your company, reach out at [andrew@plusmobileapps.com](mailto:andrew@plusmobileapps.com).

--- a/docs/blog/posts/2026-06-07-chef-mate.md
+++ b/docs/blog/posts/2026-06-07-chef-mate.md
@@ -1,0 +1,15 @@
+---
+title: Chef Mate
+date: 2026-06-07
+authors: [andrew]
+categories:
+  - Multiplatform
+---
+
+# Chef Mate
+
+Chef Mate is an open source Kotlin Multiplatform recipe keeper, meal planner, and grocery list app that targets Android, iOS, and JVM (Windows, Mac, and Linux).
+
+<!-- more -->
+
+Check it out live at [chefmate.plusmobileapps.com](https://chefmate.plusmobileapps.com/) or browse the source on [GitHub](https://github.com/Plus-Mobile-Apps/chef-mate).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,7 +80,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Wolfpack+: https://wolfpack.plusmobileapps.com/
-  - Chef Mate: https://chefmate.plusmobileapps.com/
+  - Chef Mate+: https://chefmate.plusmobileapps.com/
   - Blog: 
     - blog/index.md
   - About:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Wolfpack+: https://wolfpack.plusmobileapps.com/
+  - Chef Mate: https://chefmate.plusmobileapps.com/
   - Blog: 
     - blog/index.md
   - About:

--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,6 +1,6 @@
 {% if page.file.src_uri.startswith('blog/posts') %}
 <script src="https://giscus.app/client.js"
-        data-repo="plusmobileapps/plusmobileapps.github.io"
+        data-repo="Plus-Mobile-Apps/Plus-Mobile-Apps.github.io"
         data-repo-id="R_kgDOOPiotA"
         data-category="Announcements"
         data-category-id="DIC_kwDOOPiotM4CogdG"


### PR DESCRIPTION
## Summary
- Add Chef Mate as a top-level nav tab linking to https://chefmate.plusmobileapps.com/
- Add a short blog post (2026-06-07) introducing Chef Mate, the open source KMP recipe keeper, meal planner, and grocery list app targeting Android, iOS, and JVM (Windows, Mac, Linux)

## Test plan
- [ ] Verify the Chef Mate tab renders in the top nav and links to https://chefmate.plusmobileapps.com/
- [ ] Verify the new blog post shows on the blog index with the expected summary
- [ ] Verify links to the live site and [GitHub repo](https://github.com/Plus-Mobile-Apps/chef-mate) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)