### PR TITLE
Add newsletter signup form to site footer

### DIFF
--- a/docs/stylesheets/newsletter.css
+++ b/docs/stylesheets/newsletter.css
@@ -1,0 +1,5 @@
+.newsletter {
+  border-top: .05rem solid var(--md-default-fg-color--lightest);
+  padding: 1.5rem .8rem;
+}
+.newsletter__inner { max-width: 40rem; margin: 0 auto; }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,9 @@ plugins:
         '2018/07/30/shell-scripts.html' : 'blog/posts/2018-07-30-shell-scripts.md'
         '2018/07/20/ssh.html' : 'blog/posts/2018-07-20-ssh.md'
 
+extra_css:
+  - stylesheets/newsletter.css
+
 extra:
   analytics:
     provider: google

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block footer %}
+  <section class="newsletter">
+    <div class="newsletter__inner">
+      <script async data-uid="21f135c117" src="https://plus-mobile-apps-llc.kit.com/21f135c117/index.js"></script>
+    </div>
+  </section>
+  {{ super() }}
+{% endblock %}


### PR DESCRIPTION
## What

Adds an email newsletter signup form to the **footer of every page**, powered by a Kit (ConvertKit) inline form embed.

## Why

The site previously had no way for visitors to subscribe to a newsletter. Since this is a static MkDocs Material site on GitHub Pages (no backend), email collection is handled by a third-party ESP — Kit — which stores the subscriber list and handles confirmation emails. Kit's free tier covers up to 10,000 subscribers.

## How

- **`overrides/main.html`** — extends Material's `{% block footer %}` and renders the Kit embed above the existing footer, calling `{{ super() }}` so the original footer is preserved. Uses the same `custom_dir: overrides` pattern as the existing `overrides/partials/comments.html` (Giscus).
- **`docs/stylesheets/newsletter.css`** — light wrapper styling (top border, padding, centered max-width). Kit's script styles the form itself based on the dashboard config.
- **`mkdocs.yml`** — registers the stylesheet via `extra_css`.

## Notes for reviewer

- The Kit form is a JS embed (`data-uid="21f135c117"`), so it renders client-side once the script loads — it won't appear in a raw HTML diff of the rendered page beyond the `<script>` tag.
- Verified with a local `mkdocs build`: the embed renders on the home, about, and blog pages (and applies site-wide via the footer override).
- Recommend enabling **double opt-in** in Kit's form settings for better deliverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)