### PR TITLE
Add footer newsletter signup via Kit API (no third-party script)

### DIFF
--- a/docs/javascripts/newsletter.js
+++ b/docs/javascripts/newsletter.js
@@ -1,0 +1,59 @@
+(function () {
+  // Kit (formerly ConvertKit) public API key — safe to expose client-side,
+  // it only grants access to the forms/subscribe endpoint.
+  var KIT_API_KEY = "REPLACE_WITH_KIT_PUBLIC_API_KEY";
+  var KIT_FORM_ID = "REPLACE_WITH_KIT_FORM_ID";
+
+  function init() {
+    var form = document.getElementById("newsletter-form");
+    if (!form) return;
+
+    var input = document.getElementById("newsletter-email");
+    var button = form.querySelector(".newsletter__submit");
+    var message = document.getElementById("newsletter-message");
+
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+
+      var email = input.value.trim();
+      if (!email) return;
+
+      button.disabled = true;
+      message.textContent = "Subscribing...";
+      message.dataset.state = "";
+
+      fetch("https://api.convertkit.com/v3/forms/" + KIT_FORM_ID + "/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+        body: JSON.stringify({ api_key: KIT_API_KEY, email: email }),
+      })
+        .then(function (response) {
+          if (!response.ok) throw new Error("Request failed");
+          return response.json();
+        })
+        .then(function () {
+          message.textContent = "Thanks! Check your inbox to confirm your subscription.";
+          message.dataset.state = "success";
+          form.reset();
+        })
+        .catch(function () {
+          message.textContent = "Something went wrong. Please try again.";
+          message.dataset.state = "error";
+        })
+        .finally(function () {
+          button.disabled = false;
+        });
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  // mkdocs-material navigates via instant loading; re-init after each page swap.
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(init);
+  }
+})();

--- a/docs/javascripts/newsletter.js
+++ b/docs/javascripts/newsletter.js
@@ -1,8 +1,8 @@
 (function () {
   // Kit (formerly ConvertKit) public API key — safe to expose client-side,
   // it only grants access to the forms/subscribe endpoint.
-  var KIT_API_KEY = "REPLACE_WITH_KIT_PUBLIC_API_KEY";
-  var KIT_FORM_ID = "REPLACE_WITH_KIT_FORM_ID";
+  var KIT_API_KEY = "oUdAYSfgFJFKJNPbMQDVQw";
+  var KIT_FORM_ID = "9585142";
 
   function init() {
     var form = document.getElementById("newsletter-form");

--- a/docs/stylesheets/newsletter.css
+++ b/docs/stylesheets/newsletter.css
@@ -1,0 +1,51 @@
+.newsletter {
+  border-top: .05rem solid var(--md-default-fg-color--lightest);
+  padding: 1.5rem .8rem;
+}
+.newsletter__inner { max-width: 40rem; margin: 0 auto; }
+
+.newsletter__label {
+  display: block;
+  margin-bottom: .5rem;
+  font-weight: 700;
+}
+
+.newsletter__row {
+  display: flex;
+  gap: .5rem;
+  flex-wrap: wrap;
+}
+
+.newsletter__input {
+  flex: 1 1 16rem;
+  padding: .5rem .8rem;
+  border: .05rem solid var(--md-default-fg-color--lightest);
+  border-radius: .2rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  font-size: .8rem;
+}
+
+.newsletter__submit {
+  padding: .5rem 1.2rem;
+  border: none;
+  border-radius: .2rem;
+  background: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+  font-size: .8rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.newsletter__submit:disabled {
+  opacity: .6;
+  cursor: default;
+}
+
+.newsletter__message {
+  margin: .5rem 0 0;
+  font-size: .75rem;
+}
+
+.newsletter__message[data-state="error"] { color: var(--md-typeset-color, #c00); }
+.newsletter__message[data-state="success"] { color: #2e7d32; }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,12 @@ plugins:
         '2018/07/30/shell-scripts.html' : 'blog/posts/2018-07-30-shell-scripts.md'
         '2018/07/20/ssh.html' : 'blog/posts/2018-07-20-ssh.md'
 
+extra_css:
+  - stylesheets/newsletter.css
+
+extra_javascript:
+  - javascripts/newsletter.js
+
 extra:
   analytics:
     provider: google

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block footer %}
+  <section class="newsletter">
+    <div class="newsletter__inner">
+      <form class="newsletter__form" id="newsletter-form">
+        <label class="newsletter__label" for="newsletter-email">Get new posts by email</label>
+        <div class="newsletter__row">
+          <input
+            class="newsletter__input"
+            id="newsletter-email"
+            name="email"
+            type="email"
+            placeholder="you@example.com"
+            required
+          />
+          <button class="newsletter__submit" type="submit">Subscribe</button>
+        </div>
+        <p class="newsletter__message" id="newsletter-message" role="status"></p>
+      </form>
+    </div>
+  </section>
+  {{ super() }}
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ 'javascripts/newsletter.js' | url }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adds a plain email input + button in the footer (replacing the reverted #14 third-party `<script>` embed from `kit.com`).
- On submit, JS calls Kit's public `POST /v3/forms/{form_id}/subscribe` endpoint directly via `fetch` instead of loading a foreign script on every page.
- Shows inline success/error status and disables the button while the request is in flight.

## Needs action before merge
`docs/javascripts/newsletter.js` has two placeholders that must be filled in with real values from your Kit account before this goes live:
- `KIT_API_KEY` — Settings → Advanced → API → **API Key** (not API Secret; this one is safe to expose client-side per Kit's docs).
- `KIT_FORM_ID` — the numeric form ID (visible in the URL when editing the form in Kit's dashboard). Note this is different from the `data-uid` used by the old embed script.

## Test plan
- [x] `mkdocs build` succeeds and emits `stylesheets/newsletter.css` / `javascripts/newsletter.js`
- [x] Verified in a local preview: form renders in the footer, submit disables the button, shows a status message, and posts to `https://api.convertkit.com/v3/forms/{form_id}/subscribe` (confirmed via network inspection — got the expected 401 with placeholder credentials)
- [ ] Fill in real `KIT_API_KEY` / `KIT_FORM_ID` and confirm an actual subscribe + confirmation email end-to-end